### PR TITLE
Fix overlapping items during zoom out animations

### DIFF
--- a/src/LabeledRect.js
+++ b/src/LabeledRect.js
@@ -33,6 +33,12 @@ const LabeledRect = ({
     <rect
       width={width}
       height={height}
+      fill="white"
+      className={styles.rect}
+    />
+    <rect
+      width={width}
+      height={height}
       fill={backgroundColor}
       onClick={onClick}
       className={styles.rect}


### PR DESCRIPTION
Fixes #1 

I think this addresses Dan's issue with the zoom out animation without adding too much overhead. [Here's a live version to check](https://react-flame-graph-olanjogmpg.now.sh)