### PR TITLE
Replace SVG elements with DIVs

### DIFF
--- a/src/FlameGraph.js
+++ b/src/FlameGraph.js
@@ -29,6 +29,7 @@ export default class FlameGraph extends PureComponent<Props, State> {
   // Attach the memoized function to the instance,
   // So that multiple instances will maintain their own memoized cache.
   getItemData = memoize((data, focusedNode, focusNode, width) => ({
+    containerWidth: width,
     data,
     focusedNode,
     focusNode,
@@ -43,7 +44,6 @@ export default class FlameGraph extends PureComponent<Props, State> {
 
     return (
       <List
-        containerTagName="svg"
         height={height}
         itemCount={data.height}
         itemData={itemData}

--- a/src/ItemRenderer.js
+++ b/src/ItemRenderer.js
@@ -19,7 +19,7 @@ export default class ItemRenderer extends PureComponent<Props, void> {
   render() {
     const { data: itemData, index, style } = this.props;
 
-    const { data, focusedNode, scale } = itemData;
+    const { containerWidth, data, focusedNode, scale } = itemData;
 
     const uids = data.levels[index];
     const focusedNodeLeft = scale(focusedNode.left);
@@ -54,6 +54,7 @@ export default class ItemRenderer extends PureComponent<Props, void> {
         <LabeledRect
           backgroundColor={node.backgroundColor}
           color={node.color}
+          containerWidth={containerWidth}
           height={rowHeight}
           isDimmed={index < focusedNode.depth}
           key={uid}

--- a/src/LabeledRect.css
+++ b/src/LabeledRect.css
@@ -1,32 +1,16 @@
-.g {
-  transition: all ease-in-out 200ms;
-}
-
-.rect {
-  cursor: pointer;
-  stroke: #ffffff;
-  transition: all ease-in-out 200ms;
-}
-
-.foreignObject {
-  transition: all ease-in-out 200ms;
-  display: block;
-  pointer-events: none;
-}
-
 .div {
-  pointer-events: none;
+  position: absolute;
+
+  transition: all ease-in-out 200ms;
+
+  cursor: pointer;
+  user-select: none;
+
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
   font-size: 12px;
   font-family: sans-serif;
-  margin-left: 4px;
-  margin-right: 4px;
-  line-height: 1.5;
-  padding: 0;
   font-weight: 400;
-  text-align: left;
-  transition: all ease-in-out 200ms;
-  user-select: none;
+  line-height: 1.5;
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,7 +3,6 @@
 export const minWidthToDisplay = 1;
 export const minWidthToDisplayText = 12;
 export const rowHeight = 20;
-export const textHeight = 18;
 
 // http://gka.github.io/palettes/#colors=#37AFA9,#FEBC38|steps=25|bez=0|coL=0
 export const backgroundColorGradient = [

--- a/src/types.js
+++ b/src/types.js
@@ -17,6 +17,7 @@ export type ChartData = {|
 |};
 
 export type ItemData = {|
+  containerWidth: number,
   data: ChartData,
   focusedNode: ChartNode,
   focusNode: (chartNode: ChartNode) => void,


### PR DESCRIPTION
Possible alternative fix for issue #1 / PR #2.

* Replace several SVG elements with a DIV. Hopefully this will improve perf a bit and also enable GPU acceleration for animations.
* Replaced opacity with brightness filter to prevent overlapping text while still showing an indication of which node is selected.

Demo at: https://react-flame-graph-piamdtgdpj.now.sh

![resize](https://user-images.githubusercontent.com/29597/42774122-cb44c23e-88e5-11e8-8b98-88590dca9d69.gif)

Thoughts, @vincentriemer?