### PR TITLE
Tooltips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist
 .env.test.local
 .env.production.local
 .watchmanconfig
+.vscode
 
 package-lock.json
 npm-debug.log*

--- a/src/ItemRenderer.js
+++ b/src/ItemRenderer.js
@@ -58,6 +58,7 @@ export default class ItemRenderer extends PureComponent<Props, void> {
           isDimmed={index < focusedNode.depth}
           key={uid}
           label={node.name}
+          tooltip={node.tooltip}
           onClick={() => itemData.focusNode(node)}
           width={nodeWidth}
           x={nodeLeft - focusedNodeLeft}

--- a/src/LabeledRect.js
+++ b/src/LabeledRect.js
@@ -11,7 +11,7 @@ type Props = {|
   height: number,
   isDimmed?: boolean,
   label: string,
-  tooltip: string,
+  tooltip?: string,
   onClick: Function,
   width: number,
   x: number,

--- a/src/LabeledRect.js
+++ b/src/LabeledRect.js
@@ -11,6 +11,7 @@ type Props = {|
   height: number,
   isDimmed?: boolean,
   label: string,
+  tooltip: string,
   onClick: Function,
   width: number,
   x: number,
@@ -23,13 +24,14 @@ const LabeledRect = ({
   height,
   isDimmed = false,
   label,
+  tooltip,
   onClick,
   width,
   x,
   y,
 }: Props) => (
   <g className={styles.g} transform={`translate(${x},${y})`}>
-    <title>{label}</title>
+    <title>{tooltip || label}</title>
     <rect width={width} height={height} fill="white" className={styles.rect} />
     <rect
       width={width}

--- a/src/types.js
+++ b/src/types.js
@@ -7,7 +7,7 @@ export type ChartNode = {|
   left: number,
   name: string,
   width: number,
-  tooltip: string,
+  tooltip?: string,
 |};
 
 export type ChartData = {|

--- a/src/types.js
+++ b/src/types.js
@@ -7,6 +7,7 @@ export type ChartNode = {|
   left: number,
   name: string,
   width: number,
+  tooltip: string,
 |};
 
 export type ChartData = {|
@@ -27,4 +28,5 @@ export type RawData = {|
   name: string,
   value: number,
   children?: Array<RawData>,
+  tooltip?: string,
 |};

--- a/src/utils.js
+++ b/src/utils.js
@@ -32,7 +32,7 @@ export function transformChartData(rawData: RawData): ChartData {
     depth: number,
     leftOffset: number
   ): ChartNode {
-    const { children, name, value, tooltip = '' } = sourceNode;
+    const { children, name, value, tooltip } = sourceNode;
 
     // Add this node to the node-map and assign it a UID.
     const targetNode = (nodes[uidCounter] = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -32,7 +32,7 @@ export function transformChartData(rawData: RawData): ChartData {
     depth: number,
     leftOffset: number
   ): ChartNode {
-    const { children, name, value } = sourceNode;
+    const { children, name, value, tooltip = '' } = sourceNode;
 
     // Add this node to the node-map and assign it a UID.
     const targetNode = (nodes[uidCounter] = {
@@ -41,6 +41,7 @@ export function transformChartData(rawData: RawData): ChartData {
       depth,
       left: leftOffset,
       name,
+      tooltip,
       width: value / maxValue,
     });
 

--- a/website/src/App.js
+++ b/website/src/App.js
@@ -16,6 +16,7 @@ const simpleData = {
     {
       name: 'bar',
       value: 1,
+      tooltip: 'I am a custom tooltip',
     },
     {
       name: 'baz',
@@ -52,7 +53,7 @@ export default function App() {
       <p>
         First, define the data. Flame graphs are just a tree of "nodes". Each
         node must have a name (string) and a value (number). Nodes may also have
-        an array of children.
+        an array of children and an optional tooltip.
       </p>
       <CodeBlock value={EXAMPLE_DATA} />
       <p>
@@ -62,6 +63,7 @@ export default function App() {
       <CodeBlock value={EXAMPLE_CODE} />
       <p>The example data above will display the following flame graph:</p>
       <AutoSizedFlameGraph data={simpleData} height={105} disableScroll />
+      <p>Note: Hover on the node with the name 'bar' and see the custom tooltip appear.</p>
     </Fragment>
   );
 }

--- a/website/src/code/example-data.js
+++ b/website/src/code/example-data.js
@@ -5,6 +5,7 @@ const data = {
     {
       name: 'bar',
       value: 1,
+      tooltip: 'I am a custom tooltip'
     },
     {
       name: 'baz',


### PR DESCRIPTION
Fixes #8 

Adding an optional `tooltip` property on `data`.  If not provided, it falls back to `name` just as before.

@bvaughn Please let me know if I need to do `typeof tooltip === 'undefined'` like check in `LabeledReact`, instead of a falsy value check. Though I've specified string in the flow types, I'm not sure if it's conveyed to the user somehow. I ask this to protect against tooltip being passed as `0` or `""`.

Now that I think about it, maybe I need to add a few tests for this? Let me know.