### PR TITLE
Read color, backgroundColor from sourceNode

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -32,12 +32,20 @@ export function transformChartData(rawData: RawData): ChartData {
     depth: number,
     leftOffset: number
   ): ChartNode {
-    const { children, name, tooltip, value } = sourceNode;
+    const {
+      children,
+      name,
+      tooltip,
+      value,
+      color,
+      backgroundColor,
+    } = sourceNode;
 
     // Add this node to the node-map and assign it a UID.
     const targetNode = (nodes[uidCounter] = {
-      backgroundColor: getNodeBackgroundColor(value, maxValue),
-      color: getNodeColor(value, maxValue),
+      backgroundColor:
+        backgroundColor || getNodeBackgroundColor(value, maxValue),
+      color: color || getNodeColor(value, maxValue),
       depth,
       left: leftOffset,
       name,

--- a/website/src/App.js
+++ b/website/src/App.js
@@ -17,6 +17,7 @@ const simpleData = {
       name: 'bar',
       value: 1,
       tooltip: 'I am a custom tooltip',
+      backgroundColor: '#EF9A9A',
     },
     {
       name: 'baz',
@@ -53,7 +54,8 @@ export default function App() {
       <p>
         First, define the data. Flame graphs are just a tree of "nodes". Each
         node must have a name (string) and a value (number). Nodes may also have
-        an array of children.
+        an array of children, a custom tooltip, or specified color and background
+        color.
       </p>
       <CodeBlock value={EXAMPLE_DATA} />
       <p>

--- a/website/src/code/example-data.js
+++ b/website/src/code/example-data.js
@@ -6,9 +6,13 @@ const data = {
       name: 'bar',
       value: 1,
 
-      // Each node can also specify a "tooltip" to be shown on hover.
+      // Each node can specify a "tooltip" to be shown on hover.
       // By default, the node's "name" will be used for this.
-      tooltip: 'I am a custom tooltip'
+      tooltip: 'I am a custom tooltip',
+
+      // Each node can also provide a custom "backgroundColor"
+      // or text "color".
+      backgroundColor: '#EF9A9A'
     },
     {
       name: 'baz',


### PR DESCRIPTION
Follow up to https://github.com/bvaughn/react-flame-graph/issues/12.

Read `color` and `backgroundColor` of bars from `sourceNode`, default to `getNodeColor`/`getNodeBackgroundColor`. This could also be done by optionally passing in a custom `getNodeColor`/`getNodeBackgroundColor` but the current change seemed more in consistent with the surrounding code.

Let me know what you think.