### PR TITLE
Add onFocus callback to graph

### DIFF
--- a/src/DataConverter.js
+++ b/src/DataConverter.js
@@ -11,6 +11,7 @@ type Props = {|
   data: RawData,
   height: number,
   width: number,
+  onFocus?: (chartNode: ChartNode) => void,
 |};
 
 // Wrapper component responsible for converting raw chart data into the format required by FlameGraph.

--- a/src/FlameGraph.js
+++ b/src/FlameGraph.js
@@ -12,6 +12,7 @@ type Props = {|
   data: ChartData,
   height: number,
   width: number,
+  onFocus?: (chartNode: ChartNode) => void,
 |};
 
 type State = {|
@@ -55,8 +56,12 @@ export default class FlameGraph extends PureComponent<Props, State> {
     );
   }
 
-  focusNode = (chartNode: ChartNode) =>
+  focusNode = (chartNode: ChartNode) => {
+    if (this.props.onFocus) {
+      this.props.onFocus(chartNode);
+    }
     this.setState({
       focusedNode: chartNode,
     });
+  }
 }

--- a/website/src/App.js
+++ b/website/src/App.js
@@ -58,7 +58,8 @@ export default function App() {
       <CodeBlock value={EXAMPLE_DATA} />
       <p>
         Next, pass the data to the <code>FlameGraph</code> component, along with
-        a width and height.
+        a width and height. Optionally include an <code>onFocus</code> callback
+        to capture click events.
       </p>
       <CodeBlock value={EXAMPLE_CODE} />
       <p>The example data above will display the following flame graph:</p>

--- a/website/src/code/example-code.js
+++ b/website/src/code/example-code.js
@@ -1,3 +1,3 @@
 import { FlameGraph } from 'react-flame-graph';
 
-<FlameGraph data={data} height={200} width={400} />
+<FlameGraph data={data} height={200} width={400} onFocus={nodeFocusedCallback} />


### PR DESCRIPTION
Follow up to https://github.com/bvaughn/react-flame-graph/issues/14.

Add `onFocus ` prop to `DataConverter`/`FlameGraph` that gets called in `focusNode`