### PR TITLE
Add option for focusedId prop

### DIFF
--- a/src/DataConverter.js
+++ b/src/DataConverter.js
@@ -25,10 +25,10 @@ export default class FlameGraphProcessor extends PureComponent<Props, void> {
   // So that multiple instances will maintain their own memoized cache.
   getChartdata = memoize(rawData => transformChartData(rawData));
 
-  flameGraphRef = React.createRef();
-
-  focusNodeId(uid: string) {
-    this.flameGraphRef.current.focusNodeId(uid);
+  focusNodeId(uid: any) {
+    if (this.flameGraphRef) {
+      this.flameGraphRef.focusNodeId(uid);
+    }
   }
 
   render() {
@@ -36,6 +36,14 @@ export default class FlameGraphProcessor extends PureComponent<Props, void> {
 
     const chartData = this.getChartdata(rawData);
 
-    return <FlameGraph ref={this.flameGraphRef} data={chartData} {...rest} />;
+    return (
+      <FlameGraph
+        ref={node => {
+          this.flameGraphRef = node;
+        }}
+        data={chartData}
+        {...rest}
+      />
+    );
   }
 }

--- a/src/DataConverter.js
+++ b/src/DataConverter.js
@@ -11,7 +11,7 @@ type Props = {|
   data: RawData,
   height: number,
   width: number,
-  onChange?: (chartNode: ChartNode) => void,
+  onChange?: (chartNode: ChartNode, uid: any) => void,
 |};
 
 // Wrapper component responsible for converting raw chart data into the format required by FlameGraph.

--- a/src/DataConverter.js
+++ b/src/DataConverter.js
@@ -25,11 +25,17 @@ export default class FlameGraphProcessor extends PureComponent<Props, void> {
   // So that multiple instances will maintain their own memoized cache.
   getChartdata = memoize(rawData => transformChartData(rawData));
 
+  flameGraphRef = React.createRef();
+
+  focusNodeId(uid: string) {
+    this.flameGraphRef.current.focusNodeId(uid);
+  }
+
   render() {
     const { data: rawData, ...rest } = this.props;
 
     const chartData = this.getChartdata(rawData);
 
-    return <FlameGraph data={chartData} {...rest} />;
+    return <FlameGraph ref={this.flameGraphRef} data={chartData} {...rest} />;
   }
 }

--- a/src/FlameGraph.js
+++ b/src/FlameGraph.js
@@ -50,7 +50,7 @@ export default class FlameGraph extends PureComponent<Props, State> {
     );
   };
 
-  focusNodeId(uid: string) {
+  focusNodeId(uid: any) {
     const { nodes } = this.props.data;
     this.focusNode(nodes[uid]);
   }

--- a/src/FlameGraph.js
+++ b/src/FlameGraph.js
@@ -10,14 +10,12 @@ import { rowHeight } from './constants';
 
 type Props = {|
   data: ChartData,
-  focusedId?: string,
   height: number,
   onChange?: (chartNode: ChartNode) => void,
   width: number,
 |};
 
 type State = {|
-  focusedId?: string,
   focusedNode: ChartNode,
 |};
 
@@ -52,20 +50,9 @@ export default class FlameGraph extends PureComponent<Props, State> {
     );
   };
 
-  // If the focusedId prop changes update the focusedNode state.
-  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
-    const { focusedId } = nextProps;
-    if (focusedId === prevState.focusedId) {
-      return null;
-    }
-
-    // Default to root node
-    const { nodes, root: rootId } = nextProps.data;
-    const focusedNode = nodes[focusedId || rootId];
-    return {
-      focusedNode,
-      focusedId,
-    };
+  focusNodeId(uid: string) {
+    const { nodes } = this.props.data;
+    this.focusNode(nodes[uid]);
   }
 
   render() {

--- a/src/FlameGraph.js
+++ b/src/FlameGraph.js
@@ -10,12 +10,14 @@ import { rowHeight } from './constants';
 
 type Props = {|
   data: ChartData,
+  focusedId?: string,
   height: number,
   onChange?: (chartNode: ChartNode) => void,
   width: number,
 |};
 
 type State = {|
+  focusedId?: string,
   focusedNode: ChartNode,
 |};
 
@@ -33,7 +35,7 @@ export default class FlameGraph extends PureComponent<Props, State> {
     data,
     focusedNode,
     focusNode,
-    scale: value => value / focusedNode.width * width,
+    scale: value => (value / focusedNode.width) * width,
   }));
 
   focusNode = (chartNode: ChartNode) => {
@@ -49,6 +51,22 @@ export default class FlameGraph extends PureComponent<Props, State> {
       }
     );
   };
+
+  // If the focusedId prop changes update the focusedNode state.
+  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
+    const { focusedId } = nextProps;
+    if (focusedId === prevState.focusedId) {
+      return null;
+    }
+
+    // Default to root node
+    const { nodes, root: rootId } = nextProps.data;
+    const focusedNode = nodes[focusedId || rootId];
+    return {
+      focusedNode,
+      focusedId,
+    };
+  }
 
   render() {
     const { data, height, width } = this.props;

--- a/src/FlameGraph.js
+++ b/src/FlameGraph.js
@@ -11,7 +11,7 @@ import { rowHeight } from './constants';
 type Props = {|
   data: ChartData,
   height: number,
-  onChange?: (chartNode: ChartNode) => void,
+  onChange?: (chartNode: ChartNode, uid: any) => void,
   width: number,
 |};
 
@@ -36,7 +36,7 @@ export default class FlameGraph extends PureComponent<Props, State> {
     scale: value => (value / focusedNode.width) * width,
   }));
 
-  focusNode = (chartNode: ChartNode) => {
+  focusNode = (chartNode: ChartNode, uid: any) => {
     this.setState(
       {
         focusedNode: chartNode,
@@ -44,7 +44,7 @@ export default class FlameGraph extends PureComponent<Props, State> {
       () => {
         const { onChange } = this.props;
         if (typeof onChange === 'function') {
-          onChange(chartNode);
+          onChange(chartNode, uid);
         }
       }
     );
@@ -52,7 +52,7 @@ export default class FlameGraph extends PureComponent<Props, State> {
 
   focusNodeId(uid: any) {
     const { nodes } = this.props.data;
-    this.focusNode(nodes[uid]);
+    this.focusNode(nodes[uid], uid);
   }
 
   render() {

--- a/src/ItemRenderer.js
+++ b/src/ItemRenderer.js
@@ -58,7 +58,7 @@ export default class ItemRenderer extends PureComponent<Props, void> {
           isDimmed={index < focusedNode.depth}
           key={uid}
           label={node.name}
-          onClick={() => itemData.focusNode(node)}
+          onClick={() => itemData.focusNode(node, uid)}
           tooltip={node.tooltip}
           width={nodeWidth}
           x={nodeLeft - focusedNodeLeft}

--- a/src/types.js
+++ b/src/types.js
@@ -8,6 +8,7 @@ export type ChartNode = {|
   name: string,
   tooltip?: string,
   width: number,
+  uid?: any,
 |};
 
 export type ChartData = {|

--- a/src/types.js
+++ b/src/types.js
@@ -8,7 +8,6 @@ export type ChartNode = {|
   name: string,
   tooltip?: string,
   width: number,
-  uid?: any,
 |};
 
 export type ChartData = {|
@@ -21,7 +20,7 @@ export type ChartData = {|
 export type ItemData = {|
   data: ChartData,
   focusedNode: ChartNode,
-  focusNode: (chartNode: ChartNode) => void,
+  focusNode: (chartNode: ChartNode, uid: any) => void,
   scale: (value: number) => number,
 |};
 
@@ -30,4 +29,7 @@ export type RawData = {|
   name: string,
   tooltip?: string,
   value: number,
+  color?: string,
+  backgroundColor?: string,
+  uid?: any,
 |};

--- a/src/utils.js
+++ b/src/utils.js
@@ -82,7 +82,7 @@ export function transformChartData(rawData: RawData): ChartData {
 
   convertNode(rawData, 0, 0);
 
-  const rootUid = rawData.uid || 0
+  const rootUid = rawData.uid || '_0';
 
   return {
     height: levels.length,

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,19 +9,17 @@ const colorGradientLength = colorGradient.length;
 
 function getNodeBackgroundColor(value, maxValue) {
   return backgroundColorGradient[
-    Math.round(value / maxValue * (backgroundColorGradientLength - 1))
+    Math.round((value / maxValue) * (backgroundColorGradientLength - 1))
   ];
 }
 
 function getNodeColor(value, maxValue) {
   return colorGradient[
-    Math.round(value / maxValue * (colorGradientLength - 1))
+    Math.round((value / maxValue) * (colorGradientLength - 1))
   ];
 }
 
 export function transformChartData(rawData: RawData): ChartData {
-  let uidCounter = 0;
-
   const maxValue = rawData.value;
 
   const nodes = {};
@@ -30,7 +28,8 @@ export function transformChartData(rawData: RawData): ChartData {
   function convertNode(
     sourceNode: RawData,
     depth: number,
-    leftOffset: number
+    leftOffset: number,
+    indexPath: Array<nuber> = []
   ): ChartNode {
     const {
       children,
@@ -41,8 +40,10 @@ export function transformChartData(rawData: RawData): ChartData {
       backgroundColor,
     } = sourceNode;
 
+    const uid = indexPath.join('/');
+
     // Add this node to the node-map and assign it a UID.
-    const targetNode = (nodes[uidCounter] = {
+    const targetNode = (nodes[uid] = {
       backgroundColor:
         backgroundColor || getNodeBackgroundColor(value, maxValue),
       color: color || getNodeColor(value, maxValue),
@@ -57,18 +58,16 @@ export function transformChartData(rawData: RawData): ChartData {
     if (levels.length <= depth) {
       levels.push([]);
     }
-    levels[depth].push(uidCounter);
-
-    // Now that the current UID has been used, increment it.
-    uidCounter++;
+    levels[depth].push(uid);
 
     // Process node children.
     if (Array.isArray(children)) {
-      children.forEach(sourceChildNode => {
+      children.forEach((sourceChildNode, i) => {
         const targetChildNode = convertNode(
           sourceChildNode,
           depth + 1,
-          leftOffset
+          leftOffset,
+          indexPath.concat(i)
         );
         leftOffset += targetChildNode.width;
       });
@@ -83,6 +82,6 @@ export function transformChartData(rawData: RawData): ChartData {
     height: levels.length,
     levels,
     nodes,
-    root: 0,
+    root: '',
   };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,7 +42,7 @@ export function transformChartData(rawData: RawData): ChartData {
       uid,
     } = sourceNode;
 
-    const uidOrCounter = uid || uidCounter
+    const uidOrCounter = uid || `_${uidCounter}`;
 
     // Add this node to the node-map and assign it a UID.
     const targetNode = (nodes[uidOrCounter] = {


### PR DESCRIPTION
Follow up to https://github.com/bvaughn/react-flame-graph/issues/16.

Added `focusedId` prop to `FlameGraph`. When this prop is modified it will set the `focusedNode` state. In order to pass an id, switched ids to be the path of indices representing the node. We only update state on prop modification to avoid reseting the state for irrelevant prop changes.

If we wanted to focus a node in the graph we would pass its id eg `focusedId='1/0/2'`.

I wasn't sure what the right approach here was, the current approach implicitly relies on the ordering not changing in the data conversion so we know what our id will look like. However, I couldn't think of another way of uniquely identifying nodes from outside the component. One other option would be to optionally pass in our own uids ad keep track ourselves. Or we could leave the same ids as before but there would need to be a way to tell what the id for my given node is