### PR TITLE
Allow styling rowHeight and textHeight

### DIFF
--- a/src/DataConverter.js
+++ b/src/DataConverter.js
@@ -12,6 +12,8 @@ type Props = {|
   height: number,
   width: number,
   onChange?: (chartNode: ChartNode) => void,
+  rowHeight: number,
+  textHeight: number,
 |};
 
 // Wrapper component responsible for converting raw chart data into the format required by FlameGraph.

--- a/src/FlameGraph.js
+++ b/src/FlameGraph.js
@@ -6,13 +6,15 @@ import React, { PureComponent } from 'react';
 import { FixedSizeList as List } from 'react-window';
 import memoize from 'memoize-one';
 import ItemRenderer from './ItemRenderer';
-import { rowHeight } from './constants';
+import { defaultRowHeight, defaultTextHeight } from './constants';
 
 type Props = {|
   data: ChartData,
   height: number,
   onChange?: (chartNode: ChartNode) => void,
   width: number,
+  rowHeight: number,
+  textHeight: number,
 |};
 
 type State = {|
@@ -29,12 +31,16 @@ export default class FlameGraph extends PureComponent<Props, State> {
   // Memoize this wrapper object to avoid breaking PureComponent's sCU.
   // Attach the memoized function to the instance,
   // So that multiple instances will maintain their own memoized cache.
-  getItemData = memoize((data, focusedNode, focusNode, width) => ({
-    data,
-    focusedNode,
-    focusNode,
-    scale: value => value / focusedNode.width * width,
-  }));
+  getItemData = memoize(
+    (data, focusedNode, focusNode, width, rowHeight, textHeight) => ({
+      data,
+      focusedNode,
+      focusNode,
+      scale: value => value / focusedNode.width * width,
+      rowHeight,
+      textHeight,
+    })
+  );
 
   focusNode = (chartNode: ChartNode) => {
     this.setState(
@@ -51,10 +57,17 @@ export default class FlameGraph extends PureComponent<Props, State> {
   };
 
   render() {
-    const { data, height, width } = this.props;
+    const { data, height, width, rowHeight, textHeight } = this.props;
     const { focusedNode } = this.state;
 
-    const itemData = this.getItemData(data, focusedNode, this.focusNode, width);
+    const itemData = this.getItemData(
+      data,
+      focusedNode,
+      this.focusNode,
+      width,
+      rowHeight || defaultRowHeight,
+      textHeight || defaultTextHeight
+    );
 
     return (
       <List
@@ -62,7 +75,7 @@ export default class FlameGraph extends PureComponent<Props, State> {
         innerTagName="svg"
         itemCount={data.height}
         itemData={itemData}
-        itemSize={rowHeight}
+        itemSize={rowHeight || defaultRowHeight}
         width={width}
       >
         {ItemRenderer}

--- a/src/ItemRenderer.js
+++ b/src/ItemRenderer.js
@@ -4,7 +4,7 @@ import type { ItemData } from './types';
 
 import React, { PureComponent } from 'react';
 import LabeledRect from './LabeledRect';
-import { minWidthToDisplay, rowHeight } from './constants';
+import { minWidthToDisplay } from './constants';
 
 type Props = {|
   data: ItemData,
@@ -19,7 +19,7 @@ export default class ItemRenderer extends PureComponent<Props, void> {
   render() {
     const { data: itemData, index, style } = this.props;
 
-    const { data, focusedNode, scale } = itemData;
+    const { data, focusedNode, scale, rowHeight, textHeight } = itemData;
 
     const uids = data.levels[index];
     const focusedNodeLeft = scale(focusedNode.left);
@@ -55,6 +55,7 @@ export default class ItemRenderer extends PureComponent<Props, void> {
           backgroundColor={node.backgroundColor}
           color={node.color}
           height={rowHeight}
+          textHeight={textHeight}
           isDimmed={index < focusedNode.depth}
           key={uid}
           label={node.name}

--- a/src/LabeledRect.js
+++ b/src/LabeledRect.js
@@ -1,7 +1,7 @@
 /** @flow */
 
 import React from 'react';
-import { minWidthToDisplayText, textHeight } from './constants';
+import { minWidthToDisplayText } from './constants';
 
 import styles from './LabeledRect.css';
 
@@ -9,6 +9,7 @@ type Props = {|
   backgroundColor: string,
   color: string,
   height: number,
+  textHeight: number,
   isDimmed?: boolean,
   label: string,
   onClick: Function,
@@ -22,6 +23,7 @@ const LabeledRect = ({
   backgroundColor,
   color,
   height,
+  textHeight,
   isDimmed = false,
   label,
   onClick,

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,8 +2,8 @@
 
 export const minWidthToDisplay = 1;
 export const minWidthToDisplayText = 12;
-export const rowHeight = 20;
-export const textHeight = 18;
+export const defaultRowHeight = 20;
+export const defaultTextHeight = 18;
 
 // http://gka.github.io/palettes/#colors=#37AFA9,#FEBC38|steps=25|bez=0|coL=0
 export const backgroundColorGradient = [

--- a/src/types.js
+++ b/src/types.js
@@ -22,6 +22,8 @@ export type ItemData = {|
   focusedNode: ChartNode,
   focusNode: (chartNode: ChartNode) => void,
   scale: (value: number) => number,
+  rowHeight: number,
+  textHeight: number,
 |};
 
 export type RawData = {|


### PR DESCRIPTION
Add `rowHeight` and `textHeight` as props to `FlameGraph` so that they can be styled externally. Default to the previous values