### PR TITLE
Add mouseover callbacks

### DIFF
--- a/src/FlameGraph.js
+++ b/src/FlameGraph.js
@@ -1,6 +1,6 @@
 /** @flow */
 
-import type { ChartData, ChartNode } from './types';
+import type { ChartData, ChartNode, RawData } from './types';
 
 import React, { PureComponent } from 'react';
 import { FixedSizeList as List } from 'react-window';
@@ -12,8 +12,8 @@ type Props = {|
   data: ChartData,
   height: number,
   onChange?: (chartNode: ChartNode, uid: any) => void,
-  onMouseOut?: (e: any, node: ChartNode) => void,
-  onMouseOver?: (e: any, node: ChartNode) => void,
+  onMouseOut?: (e: any, node: RawData) => void,
+  onMouseOver?: (e: any, node: RawData) => void,
   width: number,
 |};
 

--- a/src/FlameGraph.js
+++ b/src/FlameGraph.js
@@ -12,6 +12,8 @@ type Props = {|
   data: ChartData,
   height: number,
   onChange?: (chartNode: ChartNode, uid: any) => void,
+  onMouseOut?: (e: any, node: ChartNode) => void,
+  onMouseOver?: (e: any, node: ChartNode) => void,
   width: number,
 |};
 
@@ -29,12 +31,16 @@ export default class FlameGraph extends PureComponent<Props, State> {
   // Memoize this wrapper object to avoid breaking PureComponent's sCU.
   // Attach the memoized function to the instance,
   // So that multiple instances will maintain their own memoized cache.
-  getItemData = memoize((data, focusedNode, focusNode, width) => ({
-    data,
-    focusedNode,
-    focusNode,
-    scale: value => value / focusedNode.width * width,
-  }));
+  getItemData = memoize(
+    (data, focusedNode, focusNode, onMouseOut, onMouseOver, width) => ({
+      data,
+      focusedNode,
+      focusNode,
+      scale: value => value / focusedNode.width * width,
+      onMouseOut,
+      onMouseOver,
+    })
+  );
 
   focusNode = (uid: any) => {
     const { nodes } = this.props.data;
@@ -53,10 +59,17 @@ export default class FlameGraph extends PureComponent<Props, State> {
   };
 
   render() {
-    const { data, height, width } = this.props;
+    const { data, height, onMouseOut, onMouseOver, width } = this.props;
     const { focusedNode } = this.state;
 
-    const itemData = this.getItemData(data, focusedNode, this.focusNode, width);
+    const itemData = this.getItemData(
+      data,
+      focusedNode,
+      this.focusNode,
+      onMouseOut,
+      onMouseOver,
+      width
+    );
 
     return (
       <List

--- a/src/ItemRenderer.js
+++ b/src/ItemRenderer.js
@@ -19,7 +19,7 @@ export default class ItemRenderer extends PureComponent<Props, void> {
   render() {
     const { data: itemData, index, style } = this.props;
 
-    const { data, focusedNode, scale } = itemData;
+    const { data, focusedNode, onMouseOver, onMouseOut, scale } = itemData;
 
     const uids = data.levels[index];
     const focusedNodeLeft = scale(focusedNode.left);
@@ -59,6 +59,8 @@ export default class ItemRenderer extends PureComponent<Props, void> {
           key={uid}
           label={node.name}
           onClick={() => itemData.focusNode(uid)}
+          onMouseOut={onMouseOut ? e => onMouseOut(e, node) : null}
+          onMouseOver={onMouseOver ? e => onMouseOver(e, node) : null}
           tooltip={node.tooltip}
           width={nodeWidth}
           x={nodeLeft - focusedNodeLeft}

--- a/src/ItemRenderer.js
+++ b/src/ItemRenderer.js
@@ -59,8 +59,8 @@ export default class ItemRenderer extends PureComponent<Props, void> {
           key={uid}
           label={node.name}
           onClick={() => itemData.focusNode(uid)}
-          onMouseOut={onMouseOut ? e => onMouseOut(e, node) : null}
-          onMouseOver={onMouseOver ? e => onMouseOver(e, node) : null}
+          onMouseOut={onMouseOut ? e => onMouseOut(e, node.source) : null}
+          onMouseOver={onMouseOver ? e => onMouseOver(e, node.source) : null}
           tooltip={node.tooltip}
           width={nodeWidth}
           x={nodeLeft - focusedNodeLeft}

--- a/src/LabeledRect.js
+++ b/src/LabeledRect.js
@@ -12,6 +12,8 @@ type Props = {|
   isDimmed?: boolean,
   label: string,
   onClick: Function,
+  onMouseOut?: Function,
+  onMouseOver?: Function,
   tooltip?: string,
   width: number,
   x: number,
@@ -25,12 +27,19 @@ const LabeledRect = ({
   isDimmed = false,
   label,
   onClick,
+  onMouseOut,
+  onMouseOver,
   tooltip,
   width,
   x,
   y,
 }: Props) => (
-  <g className={styles.g} transform={`translate(${x},${y})`}>
+  <g
+    className={styles.g}
+    transform={`translate(${x},${y})`}
+    onMouseOver={onMouseOver}
+    onMouseOut={onMouseOut}
+  >
     <title>{tooltip != null ? tooltip : label}</title>
     <rect width={width} height={height} fill="white" className={styles.rect} />
     <rect

--- a/src/types.js
+++ b/src/types.js
@@ -21,6 +21,8 @@ export type ItemData = {|
   data: ChartData,
   focusedNode: ChartNode,
   focusNode: (chartNode: ChartNode, uid: any) => void,
+  onMouseOut?: (e: any, node: ChartNode) => void,
+  onMouseOver?: (e: any, node: ChartNode) => void,
   scale: (value: number) => number,
 |};
 

--- a/src/types.js
+++ b/src/types.js
@@ -17,15 +17,6 @@ export type ChartData = {|
   root: any,
 |};
 
-export type ItemData = {|
-  data: ChartData,
-  focusedNode: ChartNode,
-  focusNode: (chartNode: ChartNode, uid: any) => void,
-  onMouseOut?: (e: any, node: ChartNode) => void,
-  onMouseOver?: (e: any, node: ChartNode) => void,
-  scale: (value: number) => number,
-|};
-
 export type RawData = {|
   children?: Array<RawData>,
   name: string,
@@ -34,4 +25,13 @@ export type RawData = {|
   color?: string,
   backgroundColor?: string,
   uid?: any,
+|};
+
+export type ItemData = {|
+  data: ChartData,
+  focusedNode: ChartNode,
+  focusNode: (chartNode: ChartNode, uid: any) => void,
+  onMouseOut?: (e: any, node: RawData) => void,
+  onMouseOver?: (e: any, node: RawData) => void,
+  scale: (value: number) => number,
 |};

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,6 +52,7 @@ export function transformChartData(rawData: RawData): ChartData {
       depth,
       left: leftOffset,
       name,
+      source: sourceNode,
       tooltip,
       width: value / maxValue,
     });

--- a/website/src/App.js
+++ b/website/src/App.js
@@ -71,6 +71,12 @@ export default function App() {
       <CodeBlock value={EXAMPLE_CODE} />
       <p>The example data above will display the following flame graph:</p>
       <AutoSizedFlameGraph data={simpleData} height={105} disableScroll />
+      <p>
+        Tooltips can be implemented by passing <code>onMouseOver</code> and{' '}
+        <code>onMouseOut</code> props to the flamegraph component. These props
+        should be defined as functions which receive the mouse event as the
+        first parameter, and the related node as the second parameter.
+      </p>
     </Fragment>
   );
 }


### PR DESCRIPTION
Adds callbacks for mouse events, allowing implementation of detail views or tooltips. e.g:

<img width="261" alt="Screen Shot 2020-01-28 at 19 08 09" src="https://user-images.githubusercontent.com/21655/73296444-a6428800-4201-11ea-80aa-e2f399ad0e7d.png">

This PR likely needs further work, I'll leave some self-review comments inline.